### PR TITLE
safari mobile px rounding bug

### DIFF
--- a/public/css/build.css
+++ b/public/css/build.css
@@ -18,7 +18,8 @@ table .buildTime {
 }
 
 header {
-    padding-bottom: 0;
+    padding-bottom: 5px;
+    padding-top: 5px;
     margin: 0;
 }
 
@@ -136,5 +137,10 @@ table tbody tr td:nth-child(6) {
 
     table .buildTime {
         width: 24px;
+    }
+
+    header {
+        padding-bottom: 3px;
+        padding-top: 3px;
     }
 }

--- a/public/css/build.css
+++ b/public/css/build.css
@@ -24,7 +24,7 @@ header {
 }
 
 thead {
-    top: 0;
+    top: -1px;
     background-color: #181C29;
     z-index: 2;
     position: sticky;


### PR DESCRIPTION
there's a sub-pixel rounding bug from my previous PR on safari mobile, resulting in a small gap above the sticky header

it only impacts the mobile screen size, and afaik only the safari browser

this fixes it while keeping some padding since the rem units were having rounding issues in safari

## The gap: 
<img width="764" alt="image" src="https://user-images.githubusercontent.com/4248857/210037952-512c472d-23f1-44f6-acca-60e061a89025.png">

## After  re-adding the padding and setting `top:-1` to ensure rounding pixel coverage:
<img width="637" alt="image" src="https://user-images.githubusercontent.com/4248857/210038305-ba969c4c-4006-48b7-93f2-96beb67ba5a8.png">
